### PR TITLE
Fixed typo in intensity type test

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
   var colorBlend = {
     overlay: function (a, b, intensity) {
-      intensity = typeof intensity === 'Undefined' ? 1 : intensity
+      intensity = typeof intensity === 'undefined' ? 1 : intensity
       return a.reduce(function (result, current, index) {
         var value = (a[index] < 128) ? (2 * b[index] * a[index] / 255) : (255 - 2 * (255 - a[index]) * (255 - b[index]) / 255)
         value = (value * intensity + (a[index] * (1 - intensity)))


### PR DESCRIPTION
`undefined` should not be capitalized
